### PR TITLE
feat: animación de salida del panel de lectura y transición de iconos de copia

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -105,12 +105,32 @@ body {
   }
 }
 
+@keyframes slideOutRight {
+  from {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateX(40px);
+    opacity: 0;
+  }
+}
+
 @keyframes fadeOverlay {
   from {
     opacity: 0;
   }
   to {
     opacity: 1;
+  }
+}
+
+@keyframes fadeOverlayOut {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
   }
 }
 
@@ -140,8 +160,16 @@ body {
   animation: slideInRight 0.24s cubic-bezier(0.2, 0.7, 0.2, 1) both;
 }
 
+.animate-slide-out-right {
+  animation: slideOutRight 0.18s var(--ease-out) both;
+}
+
 .animate-overlay {
   animation: fadeOverlay 0.18s ease both;
+}
+
+.animate-overlay-out {
+  animation: fadeOverlayOut 0.14s ease both;
 }
 
 /* Hero vignette: subtle brand tint that dissolves into page background */

--- a/src/components/ReaderOverlay.tsx
+++ b/src/components/ReaderOverlay.tsx
@@ -39,7 +39,8 @@ export function ReaderOverlay({
   selectedDescriptores,
   onClose,
   onOpenItem,
-}: ReaderOverlayProps) {
+  closing = false,
+}: ReaderOverlayProps & { closing?: boolean }) {
   const [citaCopied, setCitaCopied] = useState(false);
   const panelRef = React.useRef<HTMLDivElement>(null);
 
@@ -97,13 +98,13 @@ export function ReaderOverlay({
 
   return createPortal(
     <div
-      className="fixed inset-0 z-50 flex justify-end animate-overlay"
+      className={`fixed inset-0 z-50 flex justify-end ${closing ? "animate-overlay-out" : "animate-overlay"}`}
       style={{ background: "rgba(23, 23, 40, 0.4)", backdropFilter: "blur(2px)" }}
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
     >
       <div
         ref={panelRef}
-        className="w-[min(720px,94vw)] h-full overflow-y-auto bg-white dark:bg-neutral-950 border-l border-neutral-200 dark:border-neutral-800 animate-slide-in-right"
+        className={`w-[min(720px,94vw)] h-full overflow-y-auto bg-white dark:bg-neutral-950 border-l border-neutral-200 dark:border-neutral-800 ${closing ? "animate-slide-out-right" : "animate-slide-in-right"}`}
         style={{ scrollbarWidth: "thin" }}
       >
         {/* Barra superior */}
@@ -127,7 +128,10 @@ export function ReaderOverlay({
                 : "border-neutral-200/80 bg-white text-neutral-600 hover:border-neutral-300 dark:border-neutral-700/80 dark:bg-neutral-800 dark:text-neutral-400"
             }`}
           >
-            {citaCopied ? <Check className="w-3 h-3" /> : <ClipboardCopy className="w-3 h-3" />}
+            <span className="relative w-3 h-3">
+              <ClipboardCopy className={`w-3 h-3 absolute inset-0 transition-all duration-150 ${citaCopied ? "opacity-0 scale-75" : "opacity-100 scale-100"}`} />
+              <Check className={`w-3 h-3 absolute inset-0 transition-all duration-150 ${citaCopied ? "opacity-100 scale-100" : "opacity-0 scale-75"}`} />
+            </span>
             {citaCopied ? "Copiado" : "Citar"}
           </button>
           {item.metadatos?.resolucion && (

--- a/src/components/SearchClient.tsx
+++ b/src/components/SearchClient.tsx
@@ -82,6 +82,7 @@ export default function SearchClient() {
   // Estado del panel de lectura
   const [selectedItem, setSelectedItem] = useState<ResolutionItem | null>(null);
   const [overlayOpen, setOverlayOpen] = useState(false);
+  const [overlayClosing, setOverlayClosing] = useState(false);
 
   const inputRef = useRef<HTMLInputElement>(null);
   const historyRef = useRef<HTMLDivElement>(null);
@@ -108,6 +109,14 @@ export default function SearchClient() {
     });
   }, [debouncedQuery, yearFrom, yearTo, selectedDescriptores, selectedResultados, selectedTipos, page]);
 
+  const closeOverlay = useCallback(() => {
+    setOverlayClosing(true);
+    setTimeout(() => {
+      setOverlayOpen(false);
+      setOverlayClosing(false);
+    }, 180);
+  }, []);
+
   // Atajos de teclado: / para enfocar búsqueda, Esc para cerrar panel o limpiar consulta
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -116,8 +125,8 @@ export default function SearchClient() {
         inputRef.current?.focus();
       }
       if (e.key === "Escape") {
-        if (overlayOpen) {
-          setOverlayOpen(false);
+        if (overlayOpen && !overlayClosing) {
+          closeOverlay();
         } else if (document.activeElement === inputRef.current && query) {
           setQuery("");
         }
@@ -129,7 +138,7 @@ export default function SearchClient() {
     };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
-  }, [overlayOpen, query]);
+  }, [overlayOpen, overlayClosing, closeOverlay, query]);
 
   const availableYears = useMemo(() => {
     const years = new Set<number>();
@@ -249,8 +258,6 @@ export default function SearchClient() {
     setSelectedItem(item);
     setOverlayOpen(true);
   }, []);
-
-  const closeOverlay = useCallback(() => setOverlayOpen(false), []);
 
   // Abrir directamente una resolución vía hash (#abrir=572-2024), p.ej. desde el grafo de citas
   useEffect(() => {
@@ -513,6 +520,7 @@ export default function SearchClient() {
           selectedDescriptores={selectedDescriptores}
           onClose={closeOverlay}
           onOpenItem={openItem}
+          closing={overlayClosing}
         />
       )}
     </>

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -95,13 +95,16 @@ const ResultCard = React.memo(function ResultCard({ item, index, highlight, onOp
           <button
             onClick={copiarCita}
             title={citaCopied ? "¡Copiado!" : "Copiar cita"}
-            className={`inline-flex items-center gap-1 border rounded-md px-3 py-2 sm:px-2.5 sm:py-1.5 min-h-8 text-[11px] font-medium transition-all ${
+            className={`inline-flex items-center gap-1 border rounded-md px-3 py-2 sm:px-2.5 sm:py-1.5 min-h-8 text-[11px] font-medium transition-all duration-200 ${
               citaCopied
                 ? "border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
                 : "border-neutral-200/80 bg-white text-neutral-500 hover:border-neutral-400 dark:border-neutral-700/80 dark:bg-neutral-800 dark:text-neutral-400"
             }`}
           >
-            {citaCopied ? <Check className="w-3 h-3" /> : <ClipboardCopy className="w-3 h-3" />}
+            <span className="relative w-3 h-3">
+              <ClipboardCopy className={`w-3 h-3 absolute inset-0 transition-all duration-150 ${citaCopied ? "opacity-0 scale-75" : "opacity-100 scale-100"}`} />
+              <Check className={`w-3 h-3 absolute inset-0 transition-all duration-150 ${citaCopied ? "opacity-100 scale-100" : "opacity-0 scale-75"}`} />
+            </span>
             {citaCopied ? "Copiado" : "Citar"}
           </button>
           {item.metadatos?.resolucion && (


### PR DESCRIPTION
El panel de lectura ahora se desliza hacia la derecha al cerrarse en lugar de desaparecer instantáneamente. Los botones de citar alternan entre los iconos de copiar/verificar con una transición suave de opacidad y escala.